### PR TITLE
Version nix dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 license = "MIT"
 repository = "https://github.com/andrewshadura/rust-flopen"
 
-[target.'cfg(unix)'.dependencies]
-nix = "0"
+[dependencies]
+nix = { version = "0.27", features = ["fs"] }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
flopen had stopped working since 0.27 releases of the nix crate.

An unversioned dependency will break sooner or later. Here, we also require a specific feature.