### PR TITLE
Fix nix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "flopen"
 version = "0.1.2"
 authors = ["Andrej Shadura <andrew.shadura@collabora.co.uk>"]
 description = "Reliably open and lock a file"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 repository = "https://github.com/andrewshadura/rust-flopen"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ license = "MIT"
 repository = "https://github.com/andrewshadura/rust-flopen"
 
 [dependencies]
-nix = { version = "0.27.1", features = ["fs"] }
+nix = ">= 0.27, <1.0"
+libc = "0.2.147"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
In 8323a26a0, `nix` was pinned this crate used deprecated functionality.
To unpin it, use `flock` through `libc` directly.